### PR TITLE
[BUG FIX]: 404 page does not show when visiting wrong path

### DIFF
--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -70,6 +70,10 @@ const routes = [
       },
     ],
   },
+  {
+    path: "*",
+    element: <Custom404 />
+  }
 ];
 
 export default routes;


### PR DESCRIPTION
#### Fix #53 
### Before fix:
![Screenshot (37)](https://user-images.githubusercontent.com/56883128/208287903-db48ae91-4c0f-4919-8a2e-04c2cd025afb.png)
### After fix:
![Screenshot (39)](https://user-images.githubusercontent.com/56883128/208287906-cedbaefd-5d36-4e64-80ef-7f95b1b6fd39.png)
