### PR TITLE
[ADDED]: JSON data can be copied as pretty text

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.10.17",
     "axios": "^1.1.3",
     "formik": "^2.2.9",
+    "json-beautify": "^1.1.1",
     "lodash.merge": "^4.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/pages/dashboard/components/ResultModal.jsx
+++ b/frontend/src/pages/dashboard/components/ResultModal.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import JSONPretty from "react-json-pretty";
 import CustomModal from "../../../components/CustomModal";
 import { grey } from "@mui/material/colors";
@@ -9,10 +9,12 @@ import { toast } from "react-hot-toast";
 import { secondary } from "../../../themes/themeColors";
 import { copyTextToClipboard } from "../../../utils/utils";
 import { PartLoader } from "../../../components/CustomLoading";
+import json_beutify from 'json-beautify'
 
 const ResultModal = ({ open, setOpen, result, loading }) => {
   const [darkTheme] = useContext(ThemeContext);
   const [isCopied, setIsCopied] = useState(false);
+  const [isBeautifyCopied, setIsBeautifyCopied] = useState(false);
 
   const handleCopyClick = () => {
     copyTextToClipboard(JSON.stringify(result))
@@ -29,11 +31,29 @@ const ResultModal = ({ open, setOpen, result, loading }) => {
       });
   };
 
+  const copyJsonBeautify = () => {
+    const jsonBeautify = json_beutify(result, null, 1,1)
+    copyTextToClipboard(jsonBeautify)
+      .then(() => {
+        setIsBeautifyCopied(true);
+        toast.success("Copied !");
+        setTimeout(() => {
+          setIsBeautifyCopied(false);
+        }, 5000);
+      })
+      .catch((err) => {
+        console.log(err);
+        toast.error("Couldn't copy !");
+      });
+  };
+
   return (
     <CustomModal open={open} setOpen={setOpen} width={600}>
-      <Typography variant="h5" component="h2" color="primary" sx={{ mb: 2 }}>
-        Result
-      </Typography>
+      <Stack>
+        <Typography variant="h5" component="h2" color="primary" sx={{ mb: 2 }}>
+          Result
+        </Typography>
+      </Stack>
       <Box
         sx={{
           bgcolor: darkTheme ? secondary[900] : grey[100],
@@ -43,10 +63,17 @@ const ResultModal = ({ open, setOpen, result, loading }) => {
       >
         <CopyButton
           onClick={handleCopyClick}
-          sx={{ marginLeft: "90%" }}
+          sx={{ marginLeft: "65%" }}
           disabled={isCopied}
         >
           {isCopied ? "Done" : "Copy"}
+        </CopyButton>
+        <CopyButton
+          onClick={copyJsonBeautify}
+          sx={{ marginLeft: ".25rem" }}
+          disabled={isBeautifyCopied}
+        >
+          {isBeautifyCopied ? "Done" : "Beautify-copy"}
         </CopyButton>
         {loading ? (
           <PartLoader />


### PR DESCRIPTION
#### Resolves #56 
There was no option to copy data as a pretty text. So I add it

![Screenshot (46)](https://user-images.githubusercontent.com/56883128/208303346-4f3a3af8-db06-4b5b-8345-ba278d8192ff.png)
