### PR TITLE
Fixes issue no. #133

### DIFF
--- a/backend/routes/auth/auth.js
+++ b/backend/routes/auth/auth.js
@@ -14,7 +14,7 @@ const cryptr = new Cryptr("myTotallySecretKey");
 
 //VALIDATION OF USER INPUTS PREREQUISITES
 const Joi = require("joi");
-
+let authMiddleWare = require("../../middleware/authenticate");
 //AUTHORISATION RELATED API
 
 const registerSchema = Joi.object({
@@ -26,11 +26,16 @@ const loginSchema = Joi.object({
   email: Joi.string().min(6).required().email(),
   password: Joi.string().min(6).required(),
 });
-
+// adding another route to check that the user has a valid json web token
+router.get("/verify",authMiddleWare, (req, res) => {
+  res.status(200).json({
+    message: "ok",
+  });
+});
 router.post("/register", async (req, res) => {
   try {
     //CHECK IF MAIL ALREADY EXISTS
-    const emailExist = await User.findOne({ email: {$eq: req.body.email} });
+    const emailExist = await User.findOne({ email: { $eq: req.body.email } });
     if (emailExist) {
       res.status(200).send({ status: "400", message: "Email Already Exists" });
       return;
@@ -95,7 +100,7 @@ router.post("/register", async (req, res) => {
 router.post("/signin", async (req, res) => {
   //CHECKING IF EMAIL EXISTS
 
-  const user = await User.findOne({ email: {$eq: req.body.email} });
+  const user = await User.findOne({ email: { $eq: req.body.email } });
   if (!user) {
     res.status(200).send({ status: "400", message: 'Email doesn"t exist' });
     return;

--- a/frontend/src/pages/auth/ForgotPassword.jsx
+++ b/frontend/src/pages/auth/ForgotPassword.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Box,
   Button,
@@ -7,6 +7,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import axios from "axios";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { apiService } from "../../services/models/serviceModel";
 import { toast } from "react-hot-toast";
@@ -17,8 +18,39 @@ import { CustomLoaderButton } from "../../components/CustomButtons";
 import { CustomTypoDisplay } from "../../components/CustomDisplay";
 
 const ForgotPassword = () => {
+  const navigate = useNavigate();
+  let [hasToken, setHasToken] = useState(false);
+  useEffect(() => {
+    const userToken = localStorage.getItem("MockAPI-Token");
+    const headers = {
+      "auth-token": `${userToken}`,
+    };
+    axios
+      .get("https://mocker-backend.vercel.app/api/auth/verify", {
+        headers,
+      })
+      .then((res) => {
+        if (res.data.message === "ok") {
+          setHasToken(true);
+        }
+      })
+      .catch((err) => {
+        setHasToken(false);
+      });
+  }, []);
   const { id } = useParams();
-
+  const logout = () => {
+    localStorage.clear();
+    setHasToken(false);
+    navigate("/");
+  };
+  if (hasToken) {
+    return (
+      <Button variant="contained" onClick={logout} sx={{ mt: 4 }}>
+        Logout
+      </Button>
+    );
+  }
   return (
     <React.Fragment>
       {id ? <SetPasswordForm auth_token={id} /> : <VerifyForm />}

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import { Box, Button, TextField, Typography } from "@mui/material";
 import { Link, useNavigate } from "react-router-dom";
 import { apiAuth } from "../../services/models/authModel";
@@ -8,8 +9,26 @@ import { useFormik } from "formik";
 import { apiProvider } from "../../services/utilities/provider";
 import { CustomLoaderButton } from "../../components/CustomButtons";
 import { CustomPwdField } from "../../components/CustomInputFields";
-
 const Login = () => {
+  let [hasToken, setHasToken] = useState(false);
+  useEffect(() => {
+    const userToken = localStorage.getItem("MockAPI-Token");
+    const headers = {
+      "auth-token": `${userToken}`,
+    };
+    axios
+      .get("https://mocker-backend.vercel.app/api/auth/verify", {
+        headers,
+      })
+      .then((res) => {
+        if (res.data.message === "ok") {
+          setHasToken(true);
+        }
+      })
+      .catch((err) => {
+        setHasToken(false);
+      });
+  }, []);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
 
@@ -66,7 +85,18 @@ const Login = () => {
       setLoading(false);
     });
   };
-
+  const logout = () => {
+    localStorage.clear();
+    setHasToken(false);
+    navigate("/");
+  };
+  if (hasToken) {
+    return (
+      <Button variant="contained" onClick={logout} sx={{ mt: 4 }}>
+        Logout
+      </Button>
+    );
+  }
   return (
     <React.Fragment>
       <Typography variant="h4" component="h1" sx={{ mb: 2 }}>

--- a/frontend/src/pages/auth/Signup.jsx
+++ b/frontend/src/pages/auth/Signup.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import { Box, Button, TextField, Typography } from "@mui/material";
 import { Link, useNavigate } from "react-router-dom";
 import { apiAuth } from "../../services/models/authModel";
@@ -9,6 +10,25 @@ import { CustomLoaderButton } from "../../components/CustomButtons";
 import { CustomPwdField } from "../../components/CustomInputFields";
 
 const Signup = () => {
+  let [hasToken, setHasToken] = useState(false);
+  useEffect(() => {
+    const userToken = localStorage.getItem("MockAPI-Token");
+    const headers = {
+      "auth-token": `${userToken}`,
+    };
+    axios
+      .get("https://mocker-backend.vercel.app/api/auth/verify", {
+        headers,
+      })
+      .then((res) => {
+        if (res.data.message === "ok") {
+          setHasToken(true);
+        }
+      })
+      .catch((err) => {
+        setHasToken(false);
+      });
+  }, []);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
 
@@ -58,7 +78,18 @@ const Signup = () => {
       setLoading(false);
     });
   };
-
+  const logout = () => {
+    localStorage.clear();
+    setHasToken(false);
+    navigate("/");
+  };
+  if (hasToken) {
+    return (
+      <Button variant="contained" onClick={logout} sx={{ mt: 4 }}>
+        Logout
+      </Button>
+    );
+  }
   return (
     <React.Fragment>
       <Typography variant="h4" component="h1" sx={{ mb: 2 }}>


### PR DESCRIPTION
This `PR` resolve the issue of "homepage continues to display the login/signup form even after a successful login when I revisit the home page".

I have successfully addressed the issues on the home, signup, and reset-password pages. To resolve the issue, I created an additional route in the backend and implemented the useEffect hook for the login, signup, and reset-password pages.